### PR TITLE
Update gpath.svg.js

### DIFF
--- a/distribution/gpath.svg.js
+++ b/distribution/gpath.svg.js
@@ -124,7 +124,8 @@ function extractSVGpoints (shape, shape_key) {
   , point
 
   for (var key = 0; key < shape_key.length; key++) {
-    if (shape.getAttribute(shape_key[key]) === undefined) {
+    if (shape.getAttribute(shape_key[key]) === undefined ||
+      shape.getAttribute(shape_key[key]) === null) {
       point = "0"
     } else {
       point = shape.getAttribute(shape_key[key])


### PR DESCRIPTION
`shape.getAttribute(shape_key[key])` was `null` rather than `undefined` when I used it.

PS: I was using Python and Flask to run this `gpath.svg.js`. The script crashed when I was converting .svg files. Adding this line fixed it.
